### PR TITLE
Fix compilation

### DIFF
--- a/AstroPixelsPlus.ino
+++ b/AstroPixelsPlus.ino
@@ -982,8 +982,10 @@ MARCDUINO_ACTION(RemoteSecret, #APRSECRET, ({
 ////////////////
 
 MARCDUINO_ACTION(RemotePair, #APPAIR, ({
+#ifdef USE_DROID_REMOTE
                      printf("Pairing Started ...\n");
                      SMQ::startPairing();
+#endif
                  }))
 
 ////////////////

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,10 +1,10 @@
 [platformio]
-default_envs = astropixels+
+default_envs = astropixelsplus
 src_dir = .
 
 [common]
 
-[env:astropixels+]
+[env:astropixelsplus]
 platform = https://github.com/platformio/platform-espressif32.git#v5.2.0
 board = esp32dev
 framework = arduino
@@ -20,9 +20,10 @@ monitor_filters =
 build_src_filter =
   +<*>
 lib_deps =
-    https://github.com/reeltwo/Reeltwo
+    https://github.com/reeltwo/Reeltwo#23.5.3
     https://github.com/adafruit/Adafruit_NeoPixel
     https://github.com/FastLED/FastLED
+    https://github.com/DFRobot/DFRobotDFPlayerMini
 build_type = release
 build_flags = 
 	-DCORE_DEBUG_LEVEL=3


### PR DESCRIPTION
This fixes compilation of AstroPixelsPlus using the last working version of ReelTwo.
Also fixes a problem where non-alphanumeric characters (+) are not allowed (at least on Ubuntu)