### PR TITLE
pin fastled/FastLED to 3.5.0 to fix compilation errors

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,7 @@ build_src_filter =
 lib_deps =
     https://github.com/reeltwo/Reeltwo#23.5.3
     https://github.com/adafruit/Adafruit_NeoPixel
-    https://github.com/FastLED/FastLED
+    fastled/FastLED@3.5.0
     https://github.com/DFRobot/DFRobotDFPlayerMini
 build_type = release
 build_flags = 


### PR DESCRIPTION
pin FastLED  to Version 3.5.0 to solve compile errors mentioned in issue #11 